### PR TITLE
fix: Remove non-existent platformio-core Alpine package

### DIFF
--- a/esphome-mcp/Dockerfile
+++ b/esphome-mcp/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --no-cache \
     musl-dev \
     libffi-dev \
     openssl-dev \
+    rust \
     cargo \
-    platformio-core \
     git
 
 # Install Python dependencies and ESPHome


### PR DESCRIPTION
## Summary
- Removed `platformio-core` from `apk add` in the Dockerfile — it's not an Alpine package (PlatformIO is installed via pip as an ESPHome dependency)
- Added `rust` package alongside `cargo` since Alpine needs both

Fixes the build failure when installing the add-on on Home Assistant.

## Test plan
- [ ] Reinstall the add-on from HA and verify the Docker image builds successfully
- [ ] Verify ESPHome commands work through the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)