### PR TITLE
fix: Add WORKDIR so Python finds server module

### DIFF
--- a/esphome-mcp/Dockerfile
+++ b/esphome-mcp/Dockerfile
@@ -24,4 +24,6 @@ COPY run.sh /opt/
 
 RUN chmod a+x /opt/run.sh
 
+WORKDIR /opt
+
 CMD ["/opt/run.sh"]


### PR DESCRIPTION
## Summary
- Added `WORKDIR /opt` to Dockerfile so `python3 -m server.main` can find the `server` package
- Without this, Python starts in `/` and raises `ModuleNotFoundError: No module named 'server'`

## Test plan
- [ ] Restart the add-on in HA and verify the MCP server starts without module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)