### PR TITLE
fix: Allow LAN connections to MCP server

### DIFF
--- a/esphome-mcp/server/main.py
+++ b/esphome-mcp/server/main.py
@@ -18,6 +18,7 @@ log = logging.getLogger("esphome-mcp")
 
 mcp = FastMCP(
     name="esphome",
+    host="0.0.0.0",
     stateless_http=True,
 )
 


### PR DESCRIPTION
## Summary
- Set `host="0.0.0.0"` on `FastMCP()` to disable the SDK's automatic DNS rebinding protection that only allows localhost
- Clients connecting via LAN hostname/IP were getting `421 Misdirected Request` because the Host header didn't match `127.0.0.1`
- Bearer token auth already secures the endpoint

## Test plan
- [ ] Rebuild add-on in HA (reload repo → uninstall → reinstall)
- [ ] Connect from Claude Code using the HA hostname or IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)