### PR TITLE
Fix ESP compiles: build on glibc base; add OTA flash + background builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to this project will be documented in this file.
 - **Bert Berrevoets** — Project author
 - **Claude Code** — AI-assisted development
 
+## [1.2.0] - 2026-05-20 (glibc fork)
+
+### Changed
+
+- Rebased the image on the official `ghcr.io/esphome/esphome` (Debian/glibc)
+  image. The previous Alpine/musl base could not run ESPHome's glibc ESP
+  cross-toolchains (`xtensa-lx106-elf-g++`), so every compile failed with
+  `not found` (exit 127). Compiles/flashes now work.
+- Replaced bashio/`with-contenv` startup with a plain `/data/options.json`
+  read; cleared the base image's inherited `ENTRYPOINT` and `HEALTHCHECK`
+  (the dashboard healthcheck caused a ~60s restart loop).
+- Default port moved to **8098** so the fork can run beside the original.
+
+### Added
+
+- Background builds: `esphome_compile` / `esphome_flash` run in a thread and
+  return a pollable handle for long builds, with new `esphome_build_status`
+  to check progress — avoids MCP request timeouts on multi-minute compiles.
+- `esphome_flash` forces OTA (`--device <name>.local`) so it no longer hangs
+  on the interactive serial/OTA chooser when USB adapters are present.
+
 ## [1.0.0] - 2026-03-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - **Bert Berrevoets** — Project author
 - **Claude Code** — AI-assisted development
 
-## [1.2.0] - 2026-05-20 (glibc fork)
+## [1.1.0] - 2026-05-20
 
 ### Changed
 
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file.
 - Replaced bashio/`with-contenv` startup with a plain `/data/options.json`
   read; cleared the base image's inherited `ENTRYPOINT` and `HEALTHCHECK`
   (the dashboard healthcheck caused a ~60s restart loop).
-- Default port moved to **8098** so the fork can run beside the original.
+- `run.sh` sets `PLATFORMIO_CORE_DIR` to the shared
+  `/config/esphome/.esphome/.platformio` so toolchains are reused across
+  builds and shared with the ESPHome Device Builder add-on.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ instead of SSH, getting direct access to ESPHome CLI and the
 - `esphome-mcp/` — The add-on
   - `config.yaml` — HA add-on manifest (name, version, ports, options)
   - `build.yaml` — Multi-arch Docker build config
-  - `Dockerfile` — Alpine + Python + ESPHome container
+  - `Dockerfile` — built on the official ESPHome (Debian/glibc) image
   - `run.sh` — Add-on entry point (reads config, starts server)
   - `requirements.txt` — Python dependencies (mcp, uvicorn, pyyaml)
   - `server/` — Python package
@@ -29,9 +29,12 @@ instead of SSH, getting direct access to ESPHome CLI and the
 
 - **Auth**: Bearer token in `Authorization` header; auto-generated if not
   configured, persisted to `/data/auth_token`
-- **Transport**: Streamable HTTP on port 8099 at `/mcp`
+- **Transport**: Streamable HTTP on port 8098 at `/mcp`
 - **Secrets**: `secrets.yaml` is explicitly rejected in push/pull tools
-- **ESPHome**: Installed at build time via pip in the Docker image
+- **ESPHome**: Provided by the official `ghcr.io/esphome/esphome`
+  (Debian/glibc) base image — required so the ESP cross-toolchains can run
+- **Builds**: compile/flash run as background jobs; poll with
+  `esphome_build_status` when a build outlives the sync window
 - **Config mapping**: HA Supervisor maps `/config/` into the container
 
 ## Building / Testing
@@ -40,8 +43,8 @@ The add-on is built by HA Supervisor when installed. For local testing:
 
 ```bash
 cd esphome-mcp
-docker build --build-arg BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21 -t esphome-mcp .
-docker run -p 8099:8099 -v /path/to/config:/config -e ESPHOME_MCP_AUTH_TOKEN=test esphome-mcp
+docker build --build-arg BUILD_FROM=ghcr.io/esphome/esphome:2026.4.5 -t esphome-mcp .
+docker run -p 8098:8098 -v /path/to/config:/config -e ESPHOME_MCP_AUTH_TOKEN=test esphome-mcp
 ```
 
 ## Deployment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ instead of SSH, getting direct access to ESPHome CLI and the
 
 - **Auth**: Bearer token in `Authorization` header; auto-generated if not
   configured, persisted to `/data/auth_token`
-- **Transport**: Streamable HTTP on port 8098 at `/mcp`
+- **Transport**: Streamable HTTP on port 8099 at `/mcp`
 - **Secrets**: `secrets.yaml` is explicitly rejected in push/pull tools
 - **ESPHome**: Provided by the official `ghcr.io/esphome/esphome`
   (Debian/glibc) base image — required so the ESP cross-toolchains can run
@@ -44,7 +44,7 @@ The add-on is built by HA Supervisor when installed. For local testing:
 ```bash
 cd esphome-mcp
 docker build --build-arg BUILD_FROM=ghcr.io/esphome/esphome:2026.4.5 -t esphome-mcp .
-docker run -p 8098:8098 -v /path/to/config:/config -e ESPHOME_MCP_AUTH_TOKEN=test esphome-mcp
+docker run -p 8099:8099 -v /path/to/config:/config -e ESPHOME_MCP_AUTH_TOKEN=test esphome-mcp
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Assistant add-on with direct filesystem access — no SSH required.
      "mcpServers": {
        "esphome": {
          "type": "http",
-         "url": "http://<your-ha-host>:8098/mcp",
+         "url": "http://<your-ha-host>:8099/mcp",
          "headers": {
            "Authorization": "Bearer ${ESPHOME_MCP_TOKEN}"
          }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Assistant add-on with direct filesystem access — no SSH required.
      "mcpServers": {
        "esphome": {
          "type": "http",
-         "url": "http://<your-ha-host>:8099/mcp",
+         "url": "http://<your-ha-host>:8098/mcp",
          "headers": {
            "Authorization": "Bearer ${ESPHOME_MCP_TOKEN}"
          }

--- a/esphome-mcp/DOCS.md
+++ b/esphome-mcp/DOCS.md
@@ -46,7 +46,7 @@ auth_token: "my-secret-token"
      "mcpServers": {
        "esphome": {
          "type": "http",
-         "url": "http://<your-ha-host>:8099/mcp",
+         "url": "http://<your-ha-host>:8098/mcp",
          "headers": {
            "Authorization": "Bearer ${ESPHOME_MCP_TOKEN}"
          }
@@ -63,8 +63,9 @@ auth_token: "my-secret-token"
 | ---- | ----------- |
 | `esphome_list_devices` | List device configs with names |
 | `esphome_validate` | Validate a device YAML config |
-| `esphome_compile` | Compile firmware for a device |
-| `esphome_flash` | OTA flash a device |
+| `esphome_compile` | Compile firmware (background; returns inline or a poll handle) |
+| `esphome_flash` | OTA flash a device (background; returns inline or a poll handle) |
+| `esphome_build_status` | Poll the latest background compile/flash for a device |
 | `esphome_logs` | Get recent device logs (snapshot) |
 | `esphome_push_files` | Write YAML files to the config directory |
 | `esphome_pull_files` | Read YAML files from the config directory |
@@ -75,10 +76,18 @@ auth_token: "my-secret-token"
 
 - All requests require a valid Bearer token in the Authorization header.
 - `secrets.yaml` is explicitly rejected in push/pull operations.
-- The add-on exposes port 8099 — ensure your network is trusted or use
+- The add-on exposes port 8098 — ensure your network is trusted or use
   a reverse proxy with TLS.
 
 ## Network
 
-The add-on listens on port **8099** (TCP). Make sure this port is
+The add-on listens on port **8098** (TCP). Make sure this port is
 accessible from your development machine.
+
+## Long-running builds
+
+Compiles (and the compile step of a flash) can take several minutes,
+especially the first build of a device. These run in the background: if a
+build finishes within ~45s the full output is returned immediately;
+otherwise the tool returns a handle and you poll `esphome_build_status`
+with the device name until it reports `done` or `failed`.

--- a/esphome-mcp/DOCS.md
+++ b/esphome-mcp/DOCS.md
@@ -46,7 +46,7 @@ auth_token: "my-secret-token"
      "mcpServers": {
        "esphome": {
          "type": "http",
-         "url": "http://<your-ha-host>:8098/mcp",
+         "url": "http://<your-ha-host>:8099/mcp",
          "headers": {
            "Authorization": "Bearer ${ESPHOME_MCP_TOKEN}"
          }
@@ -76,12 +76,12 @@ auth_token: "my-secret-token"
 
 - All requests require a valid Bearer token in the Authorization header.
 - `secrets.yaml` is explicitly rejected in push/pull operations.
-- The add-on exposes port 8098 — ensure your network is trusted or use
+- The add-on exposes port 8099 — ensure your network is trusted or use
   a reverse proxy with TLS.
 
 ## Network
 
-The add-on listens on port **8098** (TCP). Make sure this port is
+The add-on listens on port **8099** (TCP). Make sure this port is
 accessible from your development machine.
 
 ## Long-running builds

--- a/esphome-mcp/Dockerfile
+++ b/esphome-mcp/Dockerfile
@@ -16,6 +16,10 @@ RUN chmod a+x /opt/run.sh
 
 WORKDIR /opt
 
-# Clear the esphome image's ENTRYPOINT so CMD runs our launcher directly.
+# The official esphome image ships an ENTRYPOINT and a HEALTHCHECK that probe
+# the ESPHome dashboard. We run the MCP server instead, so clear both —
+# otherwise the failing dashboard healthcheck makes Supervisor restart the
+# add-on on a ~60s loop.
 ENTRYPOINT []
+HEALTHCHECK NONE
 CMD ["/opt/run.sh"]

--- a/esphome-mcp/Dockerfile
+++ b/esphome-mcp/Dockerfile
@@ -1,21 +1,11 @@
 ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
-# Install build dependencies for ESPHome native compilation
-RUN apk add --no-cache \
-    gcc \
-    g++ \
-    musl-dev \
-    libffi-dev \
-    openssl-dev \
-    rust \
-    cargo \
-    git
-
-# Install Python dependencies and ESPHome
+# Base image (ghcr.io/esphome/esphome) is Debian/glibc and already provides
+# esphome + PlatformIO with working ESP toolchains. We only add the MCP
+# server's Python dependencies on top.
 COPY requirements.txt /tmp/
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt \
-    && pip3 install --no-cache-dir esphome \
+RUN pip3 install --no-cache-dir --break-system-packages -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 
 # Copy server code
@@ -26,4 +16,6 @@ RUN chmod a+x /opt/run.sh
 
 WORKDIR /opt
 
+# Clear the esphome image's ENTRYPOINT so CMD runs our launcher directly.
+ENTRYPOINT []
 CMD ["/opt/run.sh"]

--- a/esphome-mcp/build.yaml
+++ b/esphome-mcp/build.yaml
@@ -1,5 +1,3 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.21
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21
-args:
-  BUILD_ARCH: aarch64
+  aarch64: ghcr.io/esphome/esphome:2026.4.5
+  amd64: ghcr.io/esphome/esphome:2026.4.5

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,5 +1,5 @@
 name: ESPHome MCP Server
-version: 1.1.0
+version: 1.1.1
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,5 +1,5 @@
 name: ESPHome MCP Server (glibc fork)
-version: 1.1.2
+version: 1.2.0
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,5 +1,5 @@
 name: ESPHome MCP Server (glibc fork)
-version: 1.1.1
+version: 1.1.2
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,18 +1,19 @@
-name: ESPHome MCP Server
-version: 1.0.0
+name: ESPHome MCP Server (glibc fork)
+version: 1.1.0
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools
   for Claude Code. Runs ESPHome commands locally on Home Assistant with
-  direct filesystem access — no SSH required.
-url: https://github.com/bberrevoets/ha-addon-esphome-mcp
+  direct filesystem access — no SSH required. Built on the official ESPHome
+  (Debian/glibc) image so device compilation/flashing works.
+url: https://github.com/ojkaas/ha-addon-esphome-mcp
 arch:
   - aarch64
   - amd64
 ports:
-  8099/tcp: 8099
+  8098/tcp: 8098
 ports_description:
-  8099/tcp: MCP Streamable HTTP endpoint
+  8098/tcp: MCP Streamable HTTP endpoint
 map:
   - config:rw
 options:

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,5 +1,5 @@
 name: ESPHome MCP Server (glibc fork)
-version: 1.1.0
+version: 1.1.1
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools

--- a/esphome-mcp/config.yaml
+++ b/esphome-mcp/config.yaml
@@ -1,19 +1,19 @@
-name: ESPHome MCP Server (glibc fork)
-version: 1.2.0
+name: ESPHome MCP Server
+version: 1.1.0
 slug: esphome-mcp
 description: >-
   MCP (Model Context Protocol) server exposing ESPHome operations as tools
   for Claude Code. Runs ESPHome commands locally on Home Assistant with
   direct filesystem access — no SSH required. Built on the official ESPHome
   (Debian/glibc) image so device compilation/flashing works.
-url: https://github.com/ojkaas/ha-addon-esphome-mcp
+url: https://github.com/bberrevoets/ha-addon-esphome-mcp
 arch:
   - aarch64
   - amd64
 ports:
-  8098/tcp: 8098
+  8099/tcp: 8099
 ports_description:
-  8098/tcp: MCP Streamable HTTP endpoint
+  8099/tcp: MCP Streamable HTTP endpoint
 map:
   - config:rw
 options:

--- a/esphome-mcp/run.sh
+++ b/esphome-mcp/run.sh
@@ -1,11 +1,17 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/env bash
 # ==============================================================================
-# ESPHome MCP Server — Add-on entry point
+# ESPHome MCP Server — Add-on entry point (glibc base, no bashio)
 # ==============================================================================
 set -e
 
-# Read auth token from add-on config
-AUTH_TOKEN="$(bashio::config 'auth_token')"
+OPTIONS_FILE="/data/options.json"
+
+# Read auth token from add-on config (replaces bashio::config)
+AUTH_TOKEN="$(python3 -c "import json,sys;
+try:
+    print(json.load(open('${OPTIONS_FILE}')).get('auth_token') or '')
+except Exception:
+    print('')" 2>/dev/null || true)"
 
 # Auto-generate token if not configured
 if [ -z "$AUTH_TOKEN" ] || [ "$AUTH_TOKEN" = "null" ]; then
@@ -13,19 +19,24 @@ if [ -z "$AUTH_TOKEN" ] || [ "$AUTH_TOKEN" = "null" ]; then
     if [ ! -f "$TOKEN_FILE" ]; then
         AUTH_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
         echo "$AUTH_TOKEN" > "$TOKEN_FILE"
-        bashio::log.info "Generated new auth token — retrieve it from the add-on logs"
     else
         AUTH_TOKEN="$(cat "$TOKEN_FILE")"
     fi
-    bashio::log.warning "==================================================="
-    bashio::log.warning "  MCP Auth Token: ${AUTH_TOKEN}"
-    bashio::log.warning "==================================================="
-    bashio::log.warning "Set ESPHOME_MCP_TOKEN in your Claude Code environment"
-    bashio::log.warning "to this value, or configure it in the add-on options."
+    echo "[WARN] ==================================================="
+    echo "[WARN]   MCP Auth Token: ${AUTH_TOKEN}"
+    echo "[WARN] ==================================================="
+    echo "[WARN] Set this token in your MCP client's Authorization header."
 fi
 
 export ESPHOME_MCP_AUTH_TOKEN="$AUTH_TOKEN"
 export ESPHOME_DIR="/config/esphome"
 
-bashio::log.info "Starting ESPHome MCP Server on port 8099..."
+# Run on a non-default port so this fork can coexist with the original add-on.
+export MCP_PORT="${MCP_PORT:-8098}"
+
+# Reuse the PlatformIO toolchains/cache the official ESPHome Device Builder
+# add-on already downloaded under /config, avoiding a second download.
+export PLATFORMIO_CORE_DIR="/config/esphome/.esphome/.platformio"
+
+echo "[INFO] Starting ESPHome MCP Server on port ${MCP_PORT}..."
 exec python3 -m server.main

--- a/esphome-mcp/run.sh
+++ b/esphome-mcp/run.sh
@@ -31,9 +31,6 @@ fi
 export ESPHOME_MCP_AUTH_TOKEN="$AUTH_TOKEN"
 export ESPHOME_DIR="/config/esphome"
 
-# Run on a non-default port so this fork can coexist with the original add-on.
-export MCP_PORT="${MCP_PORT:-8098}"
-
 # Reuse the PlatformIO toolchains/cache the official ESPHome Device Builder
 # add-on already downloaded under /config, avoiding a second download.
 export PLATFORMIO_CORE_DIR="/config/esphome/.esphome/.platformio"

--- a/esphome-mcp/server/main.py
+++ b/esphome-mcp/server/main.py
@@ -50,6 +50,10 @@ def esphome_validate(device: str) -> str:
 def esphome_compile(device: str) -> str:
     """Compile ESPHome firmware for a device.
 
+    The build runs in the background. If it finishes quickly the full output
+    is returned inline; if it takes longer than the sync window, a pollable
+    handle is returned — check progress with esphome_build_status(device).
+
     Args:
         device: Device name (e.g. 'statusdisplay') or YAML filename.
     """
@@ -60,10 +64,26 @@ def esphome_compile(device: str) -> str:
 def esphome_flash(device: str) -> str:
     """OTA flash a device.
 
+    Like esphome_compile, this runs in the background and may return a
+    pollable handle for long uploads — check esphome_build_status(device).
+
     Args:
         device: Device name (e.g. 'statusdisplay') or YAML filename.
     """
     return tools.flash(device)
+
+
+@mcp.tool()
+def esphome_build_status(device: str) -> str:
+    """Get the status/output of the latest background compile or flash.
+
+    Use this to poll a build that esphome_compile / esphome_flash reported as
+    still running. Returns running progress (tail) or the final result.
+
+    Args:
+        device: Device name (e.g. 'statusdisplay') or YAML filename.
+    """
+    return tools.build_status(device)
 
 
 @mcp.tool()
@@ -138,7 +158,7 @@ app.add_middleware(BearerAuthMiddleware)
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("MCP_PORT", "8099"))
+    port = int(os.environ.get("MCP_PORT", "8098"))
     log.info("ESPHome MCP Server starting on port %d", port)
     uvicorn.run(
         "server.main:app",

--- a/esphome-mcp/server/main.py
+++ b/esphome-mcp/server/main.py
@@ -158,7 +158,7 @@ app.add_middleware(BearerAuthMiddleware)
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("MCP_PORT", "8098"))
+    port = int(os.environ.get("MCP_PORT", "8099"))
     log.info("ESPHome MCP Server starting on port %d", port)
     uvicorn.run(
         "server.main:app",

--- a/esphome-mcp/server/tools.py
+++ b/esphome-mcp/server/tools.py
@@ -7,6 +7,7 @@ import base64
 import glob
 import logging
 import os
+import re
 import subprocess
 import threading
 import time
@@ -174,6 +175,23 @@ def _await_or_handle(key: str, job: dict, label: str) -> str:
     return output
 
 
+def _resolve_substitutions(value: str, subs: dict) -> str:
+    """Resolve ${var} / $var references in a string against the subs map.
+
+    Unknown references are left untouched (so the caller's '$' guards still
+    fire for genuinely unresolved names).
+    """
+    if not isinstance(value, str) or "$" not in value:
+        return value
+
+    def repl(match):
+        key = match.group(1) or match.group(2)
+        replacement = subs.get(key)
+        return str(replacement) if replacement is not None else match.group(0)
+
+    return re.sub(r"\$\{(\w+)\}|\$(\w+)", repl, value)
+
+
 def _parse_device_info(yaml_path: str) -> dict:
     """Parse basic device info from a YAML file."""
     try:
@@ -185,12 +203,27 @@ def _parse_device_info(yaml_path: str) -> dict:
                 return f"!secret {loader.construct_scalar(node)}"
 
             SecretLoader.add_constructor("!secret", secret_constructor)
-            data = yaml.load(f, Loader=SecretLoader)
 
-        esphome_section = data.get("esphome", {})
+            # ESPHome configs carry many custom tags (!lambda, !include,
+            # !extend, !remove, ...). We only need scalar metadata here, so
+            # map any unrecognised tag to None instead of crashing the load.
+            def _ignore_unknown(loader, tag_suffix, node):
+                return None
+
+            SecretLoader.add_multi_constructor("!", _ignore_unknown)
+            data = yaml.load(f, Loader=SecretLoader) or {}
+
+        subs = data.get("substitutions", {}) or {}
+        esphome_section = data.get("esphome", {}) or {}
+        name = _resolve_substitutions(
+            esphome_section.get("name", "unknown"), subs
+        )
+        friendly_name = _resolve_substitutions(
+            esphome_section.get("friendly_name", ""), subs
+        )
         return {
-            "name": esphome_section.get("name", "unknown"),
-            "friendly_name": esphome_section.get("friendly_name", ""),
+            "name": name,
+            "friendly_name": friendly_name,
             "file": os.path.basename(yaml_path),
         }
     except Exception as e:

--- a/esphome-mcp/server/tools.py
+++ b/esphome-mcp/server/tools.py
@@ -154,7 +154,15 @@ def flash(device: str) -> str:
     yaml_path = _device_yaml_path(device)
     if not os.path.isfile(yaml_path):
         return f"Device config not found: {yaml_path}"
-    return _run([ESPHOME_BIN, "run", yaml_path, "--no-logs"], timeout=600)
+    # Force OTA and run non-interactively. The add-on container may also expose
+    # USB serial adapters (/dev/ttyUSB*), which makes `esphome run` prompt for
+    # an upload target and crash with EOFError (no stdin under MCP). Target the
+    # device's mDNS name so the upload always goes Over-The-Air.
+    cmd = [ESPHOME_BIN, "run", yaml_path, "--no-logs"]
+    name = _parse_device_info(yaml_path).get("name", "")
+    if name and name not in ("unknown", "error") and "$" not in name:
+        cmd += ["--device", f"{name}.local"]
+    return _run(cmd, timeout=600)
 
 
 def logs(device: str, num_lines: int = 50) -> str:

--- a/esphome-mcp/server/tools.py
+++ b/esphome-mcp/server/tools.py
@@ -8,6 +8,8 @@ import glob
 import logging
 import os
 import subprocess
+import threading
+import time
 
 import yaml
 
@@ -17,6 +19,18 @@ ESPHOME_DIR = os.environ.get("ESPHOME_DIR", "/config/esphome")
 ESPHOME_BIN = "esphome"
 
 FORBIDDEN_FILES = {"secrets.yaml", ".secret.yaml"}
+
+# How long compile/flash wait synchronously before returning a pollable
+# handle. Must stay comfortably under the MCP client's request timeout so a
+# long build returns a handle instead of erroring with a transport timeout.
+SYNC_WAIT_WINDOW = 45
+# Hard server-side caps on background builds.
+COMPILE_TIMEOUT = 600
+FLASH_TIMEOUT = 900
+
+# Background build registry, keyed by device YAML filename.
+_BUILDS: dict[str, dict] = {}
+_BUILDS_LOCK = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +77,101 @@ def _run(cmd: list[str], timeout: int = 120, cwd: str | None = None) -> str:
         return f"Command timed out after {timeout}s"
     except FileNotFoundError as e:
         return f"Command not found: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Background builds (compile/flash) — long jobs run in a thread so a slow
+# build returns a pollable handle instead of hitting the MCP request timeout.
+# ---------------------------------------------------------------------------
+def _build_worker(key: str, cmd: list[str], timeout: int) -> None:
+    job = _BUILDS[key]
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=ESPHOME_DIR,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except FileNotFoundError as e:
+        with _BUILDS_LOCK:
+            job["status"] = "failed"
+            job["returncode"] = -1
+            job["lines"].append(f"Command not found: {e}")
+            job["finished"] = time.time()
+        return
+
+    killer = threading.Timer(timeout, proc.kill)
+    killer.start()
+    try:
+        for line in proc.stdout:
+            with _BUILDS_LOCK:
+                job["lines"].append(line.rstrip("\n"))
+        proc.wait()
+    finally:
+        killer.cancel()
+
+    with _BUILDS_LOCK:
+        job["returncode"] = proc.returncode
+        job["finished"] = time.time()
+        if proc.returncode == 0:
+            job["status"] = "done"
+        elif proc.returncode is not None and proc.returncode < 0:
+            job["status"] = "failed"
+            job["lines"].append(f"[killed: exceeded {timeout}s timeout]")
+        else:
+            job["status"] = "failed"
+
+
+def _start_build(key: str, cmd: list[str], timeout: int) -> dict:
+    """Start (or reuse a running) background build for `key`."""
+    with _BUILDS_LOCK:
+        job = _BUILDS.get(key)
+        if job and job["status"] == "running":
+            return job
+        job = {
+            "status": "running",
+            "lines": [],
+            "returncode": None,
+            "cmd": cmd,
+            "started": time.time(),
+            "finished": None,
+        }
+        _BUILDS[key] = job
+    threading.Thread(
+        target=_build_worker, args=(key, cmd, timeout), daemon=True
+    ).start()
+    return job
+
+
+def _job_snapshot(job: dict) -> tuple[str, str, int | None]:
+    with _BUILDS_LOCK:
+        return job["status"], "\n".join(job["lines"]), job["returncode"]
+
+
+def _await_or_handle(key: str, job: dict, label: str) -> str:
+    """Wait up to SYNC_WAIT_WINDOW for completion, else return a poll handle."""
+    deadline = time.time() + SYNC_WAIT_WINDOW
+    while time.time() < deadline:
+        status, _, _ = _job_snapshot(job)
+        if status != "running":
+            break
+        time.sleep(1)
+
+    status, output, rc = _job_snapshot(job)
+    if status == "running":
+        elapsed = int(time.time() - job["started"])
+        tail = "\n".join(output.splitlines()[-15:])
+        return (
+            f"{label} still running ({elapsed}s elapsed). The build continues "
+            f"in the background — poll it with "
+            f"esphome_build_status(device='{key}').\n\n"
+            f"--- output so far (tail) ---\n{tail}"
+        )
+    if rc != 0:
+        return f"Command failed (exit {rc}):\n{output}"
+    return output
 
 
 def _parse_device_info(yaml_path: str) -> dict:
@@ -142,15 +251,17 @@ def validate(device: str) -> str:
 
 
 def compile_device(device: str) -> str:
-    """Compile ESPHome firmware for a device."""
+    """Compile ESPHome firmware for a device (runs in the background)."""
     yaml_path = _device_yaml_path(device)
     if not os.path.isfile(yaml_path):
         return f"Device config not found: {yaml_path}"
-    return _run([ESPHOME_BIN, "compile", yaml_path], timeout=300)
+    key = os.path.basename(yaml_path)
+    job = _start_build(key, [ESPHOME_BIN, "compile", yaml_path], COMPILE_TIMEOUT)
+    return _await_or_handle(key, job, "Compile")
 
 
 def flash(device: str) -> str:
-    """OTA flash a device."""
+    """OTA flash a device (runs in the background)."""
     yaml_path = _device_yaml_path(device)
     if not os.path.isfile(yaml_path):
         return f"Device config not found: {yaml_path}"
@@ -162,7 +273,31 @@ def flash(device: str) -> str:
     name = _parse_device_info(yaml_path).get("name", "")
     if name and name not in ("unknown", "error") and "$" not in name:
         cmd += ["--device", f"{name}.local"]
-    return _run(cmd, timeout=600)
+    key = os.path.basename(yaml_path)
+    job = _start_build(key, cmd, FLASH_TIMEOUT)
+    return _await_or_handle(key, job, "Flash")
+
+
+def build_status(device: str) -> str:
+    """Return the status and output of the latest compile/flash for a device."""
+    key = os.path.basename(_resolve_device(device))
+    with _BUILDS_LOCK:
+        job = _BUILDS.get(key)
+        if job is None:
+            return f"No build found for '{key}'. Start one with esphome_compile."
+        status = job["status"]
+        output = "\n".join(job["lines"])
+        rc = job["returncode"]
+        started = job["started"]
+        finished = job["finished"]
+
+    if status == "running":
+        elapsed = int(time.time() - started)
+        tail = "\n".join(output.splitlines()[-30:])
+        return f"Build running ({elapsed}s elapsed).\n\n--- output (tail) ---\n{tail}"
+
+    duration = int((finished or time.time()) - started)
+    return f"Build {status} (exit {rc}, took {duration}s):\n{output}"
 
 
 def logs(device: str, num_lines: int = 50) -> str:


### PR DESCRIPTION
## Summary

On the current **Alpine/musl** base image, every device compile fails:

```
sh: xtensa-lx106-elf-g++: not found
*** [.../api_connection.cpp.o] Error 127
```

ESPHome compiles firmware via PlatformIO, whose ESP cross-toolchains
(`xtensa-lx106-elf-g++`, etc.) are **glibc** binaries and cannot execute on
musl — so `esphome compile`/`flash` are broken on this add-on for ESP8266/
ESP32 targets. This PR rebases on the official, Debian/glibc ESPHome image
(the same approach the official ESPHome Device Builder add-on uses) and adds
a few robustness fixes discovered while getting an end-to-end OTA flash to
work.

Verified end-to-end on HA OS: validate → compile → **OTA flash succeeded**
on a nodemcuv2 (ESP8266) device.

## Changes

- **`build.yaml`**: base on `ghcr.io/esphome/esphome:2026.4.5` (Debian/glibc,
  ships esphome + PlatformIO + working toolchains) instead of the Alpine
  python base.
- **`Dockerfile`**: drop the `apk` native-compiler block (no longer needed);
  `pip install` only the MCP deps; clear the inherited `ENTRYPOINT` and
  `HEALTHCHECK` — the base image's dashboard healthcheck made Supervisor
  restart the add-on on a ~60s loop.
- **`run.sh`**: replace `bashio`/`with-contenv` (absent in the esphome image)
  with a plain `/data/options.json` read; set `PLATFORMIO_CORE_DIR` to the
  shared `/config/esphome/.esphome/.platformio` so toolchains are reused.
- **`esphome_flash`**: force OTA via `--device <name>.local`. When the
  container also has USB serial adapters, `esphome run` prompts for a target
  and crashes with `EOFError` (no stdin under MCP).
- **Background builds**: `esphome_compile` / `esphome_flash` now run in a
  thread and return a pollable handle if they exceed a short sync window,
  with a new `esphome_build_status` tool. This avoids MCP client request
  timeouts on multi-minute first builds (the build kept running server-side
  but the client gave up).
- Docs (DOCS/README/CLAUDE/CHANGELOG) updated for the glibc base and the new
  async build behavior. Port (8099), add-on name, schema, and options are
  unchanged.

## Notes / things to check

- Uses `pip install --break-system-packages` for the MCP deps; the real
  requirement is that the MCP deps land in the same interpreter that runs
  `server.main`. Works on the current esphome image; flagging in case the
  image's Python packaging changes.
- Base image tag is pinned to `2026.4.5`; you may prefer a floating tag or to
  bump it in lockstep with releases.

## Test plan

- [x] Add-on builds and starts on HA OS (no restart loop)
- [x] `esphome_validate` works
- [x] `esphome_compile` produces firmware (toolchain runs)
- [x] `esphome_flash` performs an OTA upload without an interactive prompt
- [x] Long builds return a handle; `esphome_build_status` reports completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)